### PR TITLE
feat: add API integration for parameter management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,1 @@
-# API URL
 VITE_API_URL=http://localhost:3000
-
-# Development
-VITE_DEBUG=true

--- a/src/api/params.ts
+++ b/src/api/params.ts
@@ -21,7 +21,13 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 export const paramsApi = {
   async saveParams(model: Model, params: Params): Promise<SaveParamsResponse> {
     try {
-      console.log('[API] Saving parameters:', { model, params });
+      console.log('[API] Saving parameters:', { 
+        url: `${API_URL}/api/params`,
+        model, 
+        params,
+        initData: window.Telegram?.WebApp?.initData,
+        userId: window.Telegram?.WebApp?.initDataUnsafe?.user?.id
+      });
       
       const response = await fetch(`${API_URL}/api/params`, {
         method: 'POST',
@@ -38,7 +44,11 @@ export const paramsApi = {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        console.error('[API] Failed to save parameters:', errorData);
+        console.error('[API] Failed to save parameters:', { 
+          status: response.status,
+          statusText: response.statusText,
+          error: errorData 
+        });
         throw new Error(errorData.message || 'Failed to save parameters');
       }
 
@@ -50,29 +60,4 @@ export const paramsApi = {
       throw error;
     }
   },
-
-  async getParams(userId: string): Promise<Params | null> {
-    try {
-      console.log('[API] Getting parameters for user:', userId);
-      
-      const response = await fetch(`${API_URL}/api/params?user_id=${userId}`, {
-        headers: {
-          'x-telegram-init-data': window.Telegram?.WebApp?.initData || ''
-        }
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        console.error('[API] Failed to get parameters:', errorData);
-        throw new Error(errorData.message || 'Failed to get parameters');
-      }
-
-      const data = await response.json();
-      console.log('[API] Parameters retrieved successfully:', data);
-      return data.success ? data.data : null;
-    } catch (error) {
-      console.error('[API] Error getting parameters:', error);
-      throw error;
-    }
-  }
-};
+}

--- a/src/api/params.ts
+++ b/src/api/params.ts
@@ -1,0 +1,78 @@
+import { type Model } from '@/types';
+
+interface Params {
+  image_size: string;
+  num_inference_steps: number;
+  seed: number;
+  guidance_scale: number;
+  num_images: number;
+  sync_mode: boolean;
+  enable_safety_checker: boolean;
+  output_format: 'jpeg' | 'png';
+}
+
+interface SaveParamsResponse {
+  success: boolean;
+  message: string;
+}
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+export const paramsApi = {
+  async saveParams(model: Model, params: Params): Promise<SaveParamsResponse> {
+    try {
+      console.log('[API] Saving parameters:', { model, params });
+      
+      const response = await fetch(`${API_URL}/api/params`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-telegram-init-data': window.Telegram?.WebApp?.initData || ''
+        },
+        body: JSON.stringify({
+          user_id: window.Telegram?.WebApp?.initDataUnsafe?.user?.id,
+          model,
+          params
+        })
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        console.error('[API] Failed to save parameters:', errorData);
+        throw new Error(errorData.message || 'Failed to save parameters');
+      }
+
+      const data = await response.json();
+      console.log('[API] Parameters saved successfully:', data);
+      return data;
+    } catch (error) {
+      console.error('[API] Error saving parameters:', error);
+      throw error;
+    }
+  },
+
+  async getParams(userId: string): Promise<Params | null> {
+    try {
+      console.log('[API] Getting parameters for user:', userId);
+      
+      const response = await fetch(`${API_URL}/api/params?user_id=${userId}`, {
+        headers: {
+          'x-telegram-init-data': window.Telegram?.WebApp?.initData || ''
+        }
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        console.error('[API] Failed to get parameters:', errorData);
+        throw new Error(errorData.message || 'Failed to get parameters');
+      }
+
+      const data = await response.json();
+      console.log('[API] Parameters retrieved successfully:', data);
+      return data.success ? data.data : null;
+    } catch (error) {
+      console.error('[API] Error getting parameters:', error);
+      throw error;
+    }
+  }
+};

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-red-500/50 text-red-500 dark:border-red-500 [&>svg]:text-red-500',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };


### PR DESCRIPTION
This PR adds API integration for parameter management, replacing the current WebApp.sendData() approach.

Changes:
- Added API service layer for parameter management
- Updated GenerateTab to use API instead of WebApp.sendData()
- Added loading and error states with UI feedback
- Added comprehensive logging
- Added environment configuration

To test:
1. Copy `.env.example` to `.env`
2. Set `VITE_API_URL` to your bot's API URL
3. Start the development server
4. Try saving parameters and check the logs

Note: This requires the corresponding PR in selfi-bot-v2 to be deployed first.