### PR TITLE
feat: add seed control and remove sync mode

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/src/api/parameters.ts
+++ b/src/api/parameters.ts
@@ -1,13 +1,4 @@
-import { WebApp } from '@twa-dev/types';
 import { apiRequest } from '../lib/api';
-
-declare global {
-  interface Window {
-    Telegram: {
-      WebApp: WebApp;
-    };
-  }
-}
 
 interface UserParameters {
   params: {
@@ -16,7 +7,6 @@ interface UserParameters {
     seed?: number;
     guidance_scale?: number;
     num_images?: number;
-    sync_mode?: boolean;
     enable_safety_checker?: boolean;
     output_format?: string;
     model?: any;  // Add model to params type
@@ -24,7 +14,7 @@ interface UserParameters {
 }
 
 export async function getUserParameters(): Promise<UserParameters | null> {
-  const user = window.Telegram.WebApp.initDataUnsafe.user;
+  const user = window.Telegram?.WebApp?.initDataUnsafe?.user;
   if (!user?.id) return null;
 
   try {
@@ -36,7 +26,7 @@ export async function getUserParameters(): Promise<UserParameters | null> {
 }
 
 export async function saveUserParameters(params: UserParameters['params']): Promise<UserParameters> {
-  const user = window.Telegram.WebApp.initDataUnsafe.user;
+  const user = window.Telegram?.WebApp?.initDataUnsafe?.user;
   if (!user?.id) throw new Error('No user ID found');
 
   return await apiRequest<UserParameters>('/api/params', {

--- a/src/components/generate/GenerateTab.tsx
+++ b/src/components/generate/GenerateTab.tsx
@@ -39,10 +39,6 @@ const DEFAULT_PARAMS: Params = {
   output_format: 'jpeg'
 };
 
-function generateRandomSeed(): number {
-  return Math.floor(Math.random() * 1000000);
-}
-
 export function GenerateTab() {
   const generate = useGenerate();
   const [selectedModel, setSelectedModel] = useState<Model | undefined>(undefined);

--- a/src/components/generate/GenerateTab.tsx
+++ b/src/components/generate/GenerateTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, ChangeEvent } from 'react';
 import { Card } from '../ui/components';
 import { useGenerate } from '@/hooks/useGenerate';
 import { ModelSelector } from './ModelSelector';
@@ -155,7 +155,7 @@ export function GenerateTab() {
               <Input
                 type="number"
                 value={seedInput}
-                onChange={(e) => handleSeedChange(e.target.value)}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => handleSeedChange(e.target.value)}
                 placeholder="Enter seed number"
                 className="flex-1"
               />

--- a/src/components/generate/types.ts
+++ b/src/components/generate/types.ts
@@ -2,6 +2,7 @@ import type { Model } from '@/types';
 
 export interface ModelSelectorProps {
   onSelect: (model: Model | undefined) => void;
+  defaultValue?: Model;
 }
 
 export interface AdvancedOptionsProps {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,19 @@
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'outline' | 'default';
+}
+
+export function Button({ variant = 'default', className = '', children, ...props }: ButtonProps) {
+  const baseClasses = 'font-medium flex items-center justify-center rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2';
+  const variantClasses = variant === 'outline'
+    ? 'border border-gray-300 bg-white hover:bg-gray-50'
+    : 'bg-blue-600 text-white hover:bg-blue-700';
+
+  return (
+    <button
+      className={`${baseClasses} ${variantClasses} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,10 @@
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input({ className = '', ...props }: InputProps) {
+  return (
+    <input
+      className={`w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:border-blue-500 ${className}`}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
This PR adds seed control and removes the unnecessary sync mode option:

1. Added seed control:
   - Input field for manual seed entry
   - Random seed generator button
   - Clear explanation of seed usage
2. Removed sync mode option as it's not needed
3. Updated types and defaults to match changes

The seed control allows users to:
- Enter specific seeds for reproducible results
- Generate random seeds with one click
- Keep track of seeds that produce good results

UI changes:
- Added seed input in the Image Parameters section
- Added RefreshCw icon button for random seeds
- Removed sync mode toggle from Additional Options

To test:
1. Enter a custom seed and verify it's saved
2. Generate random seeds and verify they work
3. Verify removed sync mode doesn't affect functionality
4. Check all other parameters still work as expected