### PR TITLE
fix: improve parameter saving in Generate tab

### DIFF
--- a/src/api/parameters.ts
+++ b/src/api/parameters.ts
@@ -1,5 +1,6 @@
 import { WebApp } from '@twa-dev/types';
 import { apiRequest } from '../lib/api';
+import type { Model } from '@/types';
 
 declare global {
   interface Window {
@@ -9,17 +10,20 @@ declare global {
   }
 }
 
-interface UserParameters {
-  params: {
-    image_size?: string;
-    num_inference_steps?: number;
-    seed?: number;
-    guidance_scale?: number;
-    num_images?: number;
-    sync_mode?: boolean;
-    enable_safety_checker?: boolean;
-    output_format?: string;
-    model?: any;  // Add model to params type
+export interface Params {
+  image_size?: string;
+  num_inference_steps?: number;
+  seed?: number;
+  guidance_scale?: number;
+  num_images?: number;
+  sync_mode?: boolean;
+  enable_safety_checker?: boolean;
+  output_format?: string;
+}
+
+export interface UserParameters {
+  params: Params & {
+    model?: Model;
   };
 }
 
@@ -41,9 +45,6 @@ export async function saveUserParameters(params: UserParameters['params']): Prom
 
   return await apiRequest<UserParameters>('/api/params', {
     method: 'POST',
-    body: JSON.stringify({ 
-      model: params.model,
-      params
-    })
+    body: JSON.stringify({ params })
   }, user);
 }


### PR DESCRIPTION
This PR fixes issues with parameter saving in the Generate tab.

Changes:
1. Improved types and interfaces for better type safety
   - Added explicit `Params` interface
   - Made model type more specific
   - Fixed UserParameters type structure

2. Fixed parameter saving logic
   - Removed double saving of parameters
   - Added debouncing to parameter updates (500ms)
   - Fixed model saving structure

3. Added better parameter handling
   - Added proper fallbacks to DEFAULT_PARAMS
   - Better null/undefined checking
   - Fixed parameter extraction during load

4. Improved error handling and feedback
   - Better error logging
   - Added type guards

Technical Changes:
- Added lodash debounce to prevent too frequent API calls
- Fixed type imports and exports
- Improved model and param separation in saved data
- Added proper null coalescing for default values

Testing:
1. Parameters are now properly saved on changes
2. Model selection persists
3. Default values are properly applied
4. No more excessive API calls
5. Better error feedback in console