### PR TITLE
Add generation command display to images list

### DIFF
--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -33,7 +33,8 @@ const generateCommand = (image: GeneratedImage): string => {
   }
   if (image.params.num_inference_steps) parts.push(`--s ${image.params.num_inference_steps}`);
   if (image.params.guidance_scale) parts.push(`--c ${image.params.guidance_scale}`);
-  if (image.seed) parts.push(`--seed ${image.seed}`);
+  // Always include seed as it's generated on the backend
+  parts.push(`--seed ${image.seed.toString()}`);
   if (image.loras?.[0]) {
     const lora = image.loras[0];
     parts.push(`--l ${lora.triggerWord || lora.name}:${lora.scale}`);

--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -10,7 +10,6 @@ interface ImageItemProps {
   image: GeneratedImage;
   themeParams: any;
   images: GeneratedImage[];
-  index: number;
 }
 
 const formatDateLatam = (date: Date) => {
@@ -43,7 +42,7 @@ const generateCommand = (image: GeneratedImage): string => {
   return parts.join(' ');
 };
 
-const ImageGallery = ({ images, startIndex, onClose }: { images: GeneratedImage[], startIndex: number, onClose: () => void }) => {
+const ImageGallery = ({ images, onClose }: { images: GeneratedImage[], onClose: () => void }) => {
   return (
     <div 
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
@@ -66,7 +65,7 @@ const ImageGallery = ({ images, startIndex, onClose }: { images: GeneratedImage[
   );
 };
 
-const ImageItem = ({ image, themeParams, images, index }: ImageItemProps) => {
+const ImageItem = ({ image, themeParams, images }: ImageItemProps) => {
   const [isPromptExpanded, setIsPromptExpanded] = useState(false);
   const [showCopied, setShowCopied] = useState(false);
   const [showGallery, setShowGallery] = useState(false);
@@ -151,7 +150,6 @@ const ImageItem = ({ image, themeParams, images, index }: ImageItemProps) => {
       {showGallery && (
         <ImageGallery 
           images={images}
-          startIndex={index}
           onClose={() => setShowGallery(false)}
         />
       )}
@@ -225,13 +223,12 @@ export function ImagesTab() {
   return (
     <Card className="shadow-md" style={cardStyle}>
       <div className="divide-y">
-        {allImages.map((image, index) => (
+        {allImages.map((image) => (
           <ImageItem 
             key={image.id}
             image={image}
             themeParams={themeParams}
             images={allImages}
-            index={index}
           />
         ))}
         

--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Card } from '../ui/card';
-import { ChevronDown, ChevronUp, Loader2, Copy } from 'lucide-react';
+import { Loader2, Copy } from 'lucide-react';
 import { useTelegramTheme } from '@/hooks/useTelegramTheme';
 import type { GeneratedImage } from '@/types/image';
 import { getGeneratedImages, type ImagesResponse } from '@/api/images';
@@ -42,13 +42,17 @@ const generateCommand = (image: GeneratedImage): string => {
 };
 
 const ImageItem = ({ image, themeParams }: ImageItemProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
   const [isPromptExpanded, setIsPromptExpanded] = useState(false);
   const [showCopied, setShowCopied] = useState(false);
+  const [showLargeImage, setShowLargeImage] = useState(false);
   const command = generateCommand(image);
 
   const itemStyle = {
     borderColor: `${themeParams.button_color}20`,
+  };
+
+  const commandStyle = {
+    backgroundColor: `${themeParams.button_color}10`,
   };
 
   const copyCommand = async () => {
@@ -85,7 +89,10 @@ const ImageItem = ({ image, themeParams }: ImageItemProps) => {
                 )}
               </div>
               <div className="mt-1 flex items-center gap-2">
-                <code className="text-xs text-gray-600 font-mono break-all bg-gray-100 rounded px-1 py-0.5">
+                <code 
+                  className="text-xs font-mono break-all rounded px-2 py-1 flex-1"
+                  style={commandStyle}
+                >
                   {command}
                 </code>
                 <button
@@ -103,61 +110,30 @@ const ImageItem = ({ image, themeParams }: ImageItemProps) => {
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <div className="w-16 h-16 relative shrink-0">
-              <img 
-                src={image.url} 
-                alt={image.prompt}
-                className="object-cover w-full h-full rounded"
-              />
-            </div>
-            <button
-              onClick={() => setIsExpanded(!isExpanded)}
-              className="p-1 hover:bg-black/5 rounded shrink-0"
-            >
-              {isExpanded ? (
-                <ChevronUp className="h-5 w-5" />
-              ) : (
-                <ChevronDown className="h-5 w-5" />
-              )}
-            </button>
-          </div>
+          <button 
+            onClick={() => setShowLargeImage(true)} 
+            className="w-16 h-16 relative shrink-0 rounded overflow-hidden hover:opacity-90 transition-opacity"
+          >
+            <img 
+              src={image.url} 
+              alt={image.prompt}
+              className="object-cover w-full h-full"
+            />
+          </button>
         </div>
       </div>
 
-      {isExpanded && (
-        <div className="mt-4 space-y-2 pl-4">
-          <img 
-            src={image.url}
-            alt={image.prompt}
-            className="max-w-full h-auto rounded mb-4"
-          />
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <p><strong>Prompt:</strong> {image.prompt}</p>
-              <p><strong>Seed:</strong> {image.seed}</p>
-              {image.width && image.height && (
-                <p><strong>Size:</strong> {image.width}x{image.height}</p>
-              )}
-              <p><strong>NSFW Check:</strong> {image.hasNsfw ? 'Failed' : 'Passed'}</p>
-            </div>
-            <div>
-              <p><strong>Steps:</strong> {image.params.num_inference_steps}</p>
-              <p><strong>CFG Scale:</strong> {image.params.guidance_scale}</p>
-              {image.loras && image.loras.length > 0 && (
-                <div>
-                  <strong>LoRAs:</strong>
-                  <ul className="list-disc pl-4">
-                    {image.loras.map((lora, index) => (
-                      <li key={index}>
-                        {lora.name || lora.triggerWord || lora.path} 
-                        {lora.scale && ` (scale: ${lora.scale})`}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
+      {showLargeImage && (
+        <div 
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          onClick={() => setShowLargeImage(false)}
+        >
+          <div className="max-w-[90%] max-h-[90%] relative">
+            <img 
+              src={image.url}
+              alt={image.prompt}
+              className="max-w-full max-h-[90vh] object-contain rounded"
+            />
           </div>
         </div>
       )}

--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -44,8 +44,6 @@ const generateCommand = (image: GeneratedImage): string => {
 };
 
 const ImageGallery = ({ images, startIndex, onClose }: { images: GeneratedImage[], startIndex: number, onClose: () => void }) => {
-  const [currentIndex, setCurrentIndex] = useState(startIndex);
-  
   return (
     <div 
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
@@ -53,7 +51,7 @@ const ImageGallery = ({ images, startIndex, onClose }: { images: GeneratedImage[
     >
       <div className="w-full h-full overflow-auto py-4">
         <div className="flex flex-col gap-4 items-center">
-          {images.map((image, index) => (
+          {images.map((image) => (
             <img 
               key={image.id}
               src={image.url}


### PR DESCRIPTION
This PR adds the following features to the images list:

- Shows the command that can generate the same image using inline parameters
- Adds copy button with feedback
- Collapses long prompts with show more/less button
- Uses monospace font for command display
- Improves layout and spacing

The command includes all relevant parameters:
- Aspect ratio (--ar)
- Steps (--s)
- CFG Scale (--c)
- Seed (--seed)
- LoRA with scale (--l)