### PR TITLE
fix: improve balance refresh behavior and reduce API calls

### DIFF
--- a/src/hooks/useStarBalance.ts
+++ b/src/hooks/useStarBalance.ts
@@ -1,43 +1,60 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { getUserInfo, type UserInfo } from '@/lib/api';
+
+const MIN_REFRESH_INTERVAL = 5000; // 5 seconds minimum between refreshes
 
 export function useStarBalance() {
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [lastRefreshTime, setLastRefreshTime] = useState(0); // Add timestamp tracking
+  const lastRefreshTime = useRef(0); // Use ref instead of state to prevent re-renders
+  const refreshPromise = useRef<Promise<void> | null>(null); // Track ongoing refresh
 
   const refreshBalance = useCallback(async (force = false) => {
-    // Add minimum refresh interval (5 seconds)
     const now = Date.now();
-    if (!force && now - lastRefreshTime < 5000) {
-      return;
+    if (!force && now - lastRefreshTime.current < MIN_REFRESH_INTERVAL) {
+      return; // Skip if too soon and not forced
     }
 
+    // If there's an ongoing refresh, wait for it
+    if (refreshPromise.current) {
+      return refreshPromise.current;
+    }
+
+    // Start new refresh
     try {
       setIsLoading(true);
       setError(null);
-      const info = await getUserInfo();
-      console.log('Star balance refreshed:', info.stars);
-      setUserInfo(info);
-      setLastRefreshTime(now);
+      
+      // Create and store the promise
+      refreshPromise.current = (async () => {
+        try {
+          const info = await getUserInfo();
+          setUserInfo(info);
+          lastRefreshTime.current = Date.now();
+        } finally {
+          refreshPromise.current = null; // Clear the promise reference
+        }
+      })();
+
+      await refreshPromise.current;
     } catch (err) {
       console.error('Failed to load user info:', err);
       setError('Failed to load user information');
     } finally {
       setIsLoading(false);
     }
-  }, [lastRefreshTime]);
+  }, []); // No dependencies needed since we use refs
 
   // Initial load
   useEffect(() => {
     refreshBalance(true);
-  }, [refreshBalance]);
+  }, []); // Only run on mount
 
   return {
     userInfo,
     isLoading,
     error,
-    refreshBalance: () => refreshBalance(true) // Force refresh when explicitly called
+    refreshBalance
   };
 }


### PR DESCRIPTION
This PR improves the balance refresh behavior to reduce unnecessary API calls:

- Uses `useRef` in `useStarBalance` to prevent re-renders and track ongoing requests
- Increases polling interval to 60 seconds (from 10)
- Only polls when tab is active
- Better error handling and event management
- Prevents duplicate simultaneous requests

This should significantly reduce the number of API calls while maintaining up-to-date balance information.