### PR TITLE
feat: reorder image item layout

### DIFF
--- a/src/components/images/ImagesTab.tsx
+++ b/src/components/images/ImagesTab.tsx
@@ -223,47 +223,45 @@ const ImageItem = ({ image, themeParams, images, onImageClick }: ImageItemProps)
       <div className="space-y-2">
         <div className="flex items-start gap-4">
           <div className="flex-1 min-w-0">
-            <div>
+            <div className="flex items-start gap-2">
+              <div className="flex-1 min-w-0">
+                <span className={`text-sm ${!isPromptExpanded ? "line-clamp-1" : ""}`}>
+                  {image.prompt}
+                </span>
+                {image.prompt.length > 50 && (
+                  <button
+                    onClick={() => setIsPromptExpanded(!isPromptExpanded)}
+                    className="text-xs text-gray-500 hover:text-gray-700 shrink-0 mt-0.5"
+                  >
+                    {isPromptExpanded ? 'Show less' : 'Show more'}
+                  </button>
+                )}
+              </div>
+              <button
+                onClick={copyCommand}
+                className="p-1 hover:bg-gray-100 rounded group relative shrink-0 mt-0.5"
+                title="Copy command"
+              >
+                <Copy className="h-4 w-4 text-gray-500 group-hover:text-gray-700" />
+                {showCopied && (
+                  <span className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs py-1 px-2 rounded">
+                    Copied!
+                  </span>
+                )}
+              </button>
+            </div>
+            <div className="mt-1">
+              <code 
+                className="text-xs font-mono break-all rounded px-2 py-1 block w-full"
+                style={commandStyle}
+              >
+                {command}
+              </code>
+            </div>
+            <div className="mt-2">
               <span className="text-xs text-gray-500">
                 {formatDateLatam(new Date(image.createdAt))}
               </span>
-            </div>
-            <div className="mt-1">
-              <div className="flex items-start gap-2">
-                <div className="flex-1 min-w-0">
-                  <span className={`text-sm ${!isPromptExpanded ? "line-clamp-1" : ""}`}>
-                    {image.prompt}
-                  </span>
-                  {image.prompt.length > 50 && (
-                    <button
-                      onClick={() => setIsPromptExpanded(!isPromptExpanded)}
-                      className="text-xs text-gray-500 hover:text-gray-700 shrink-0 mt-0.5"
-                    >
-                      {isPromptExpanded ? 'Show less' : 'Show more'}
-                    </button>
-                  )}
-                </div>
-                <button
-                  onClick={copyCommand}
-                  className="p-1 hover:bg-gray-100 rounded group relative shrink-0 mt-0.5"
-                  title="Copy command"
-                >
-                  <Copy className="h-4 w-4 text-gray-500 group-hover:text-gray-700" />
-                  {showCopied && (
-                    <span className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs py-1 px-2 rounded">
-                      Copied!
-                    </span>
-                  )}
-                </button>
-              </div>
-              <div className="mt-1">
-                <code 
-                  className="text-xs font-mono break-all rounded px-2 py-1 block w-full"
-                  style={commandStyle}
-                >
-                  {command}
-                </code>
-              </div>
             </div>
           </div>
           <ImageThumbnail


### PR DESCRIPTION
- Move date under command area
- Adjust spacing between elements
- Keep prompt and command at the top
- Remove extra div nesting for date