### PR TITLE
Fix: Improve seed input handling and persistence

### DIFF
--- a/src/components/generate/GenerateTab.tsx
+++ b/src/components/generate/GenerateTab.tsx
@@ -16,7 +16,7 @@ import { ImageParameters } from './ImageParameters';
 const DEFAULT_PARAMS: GenerationParameters = {
   image_size: 'landscape_4_3',
   num_inference_steps: 28,
-  seed: 0, // Default to 0 (random/aleatorio)
+  seed: 0, // Default to random seed
   guidance_scale: 3.5,
   enable_safety_checker: true,
   output_format: 'jpeg',

--- a/src/components/generate/GenerateTab.tsx
+++ b/src/components/generate/GenerateTab.tsx
@@ -16,7 +16,7 @@ import { ImageParameters } from './ImageParameters';
 const DEFAULT_PARAMS: GenerationParameters = {
   image_size: 'landscape_4_3',
   num_inference_steps: 28,
-  seed: 0, // Default to random (0) instead of generating
+  seed: 0, // Default to 0 (random/aleatorio)
   guidance_scale: 3.5,
   enable_safety_checker: true,
   output_format: 'jpeg',
@@ -29,9 +29,7 @@ export function GenerateTab() {
   const { parameters, isLoading: isLoadingParams, invalidateParameters } = useParameters();
   const [params, setParams] = useState<GenerationParameters>(() => ({
     ...DEFAULT_PARAMS,
-    ...parameters,
-    // Keep seed as 0 if parameters.seed is 0, otherwise use parameters.seed or 0
-    seed: parameters?.seed === 0 ? 0 : (parameters?.seed || 0)
+    ...parameters
   }));
   const [isSaving, setIsSaving] = useState(false);
   const themeParams = useTelegramTheme();
@@ -62,8 +60,6 @@ export function GenerateTab() {
         const updatedParams = {
           ...DEFAULT_PARAMS,
           ...parameters,
-          // Keep seed as 0 if it's 0 in parameters
-          seed: parameters.seed === 0 ? 0 : (parameters.seed || 0),
           loras: parameters.loras?.filter(lora => selectedModelIds.has(lora.path)) || [],
           ...Object.fromEntries(
             Object.entries(currentParams).filter(([key]) => 

--- a/src/components/generate/GenerateTab.tsx
+++ b/src/components/generate/GenerateTab.tsx
@@ -12,12 +12,11 @@ import { getUserModels } from '@/api/loras';
 import { useQuery } from '@tanstack/react-query';
 import { useTelegramTheme } from '@/hooks/useTelegramTheme';
 import { ImageParameters } from './ImageParameters';
-import { generateFalSeed } from '@/utils/seed';
 
 const DEFAULT_PARAMS: GenerationParameters = {
   image_size: 'landscape_4_3',
   num_inference_steps: 28,
-  seed: generateFalSeed(), // Initialize with a random seed
+  seed: 0, // Default to random (0) instead of generating
   guidance_scale: 3.5,
   enable_safety_checker: true,
   output_format: 'jpeg',
@@ -31,7 +30,8 @@ export function GenerateTab() {
   const [params, setParams] = useState<GenerationParameters>(() => ({
     ...DEFAULT_PARAMS,
     ...parameters,
-    seed: parameters?.seed || generateFalSeed() // Ensure we always have a valid seed
+    // Keep seed as 0 if parameters.seed is 0, otherwise use parameters.seed or 0
+    seed: parameters?.seed === 0 ? 0 : (parameters?.seed || 0)
   }));
   const [isSaving, setIsSaving] = useState(false);
   const themeParams = useTelegramTheme();
@@ -62,7 +62,8 @@ export function GenerateTab() {
         const updatedParams = {
           ...DEFAULT_PARAMS,
           ...parameters,
-          seed: parameters.seed || generateFalSeed(), // Ensure we always have a valid seed
+          // Keep seed as 0 if it's 0 in parameters
+          seed: parameters.seed === 0 ? 0 : (parameters.seed || 0),
           loras: parameters.loras?.filter(lora => selectedModelIds.has(lora.path)) || [],
           ...Object.fromEntries(
             Object.entries(currentParams).filter(([key]) => 

--- a/src/components/generate/ImageParameters/SeedInput.tsx
+++ b/src/components/generate/ImageParameters/SeedInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { RotateCcw, X, Info } from 'lucide-react';
 import type { TelegramThemeParams } from '@/types/telegram';
 import { generateFalSeed } from '@/utils/seed';
@@ -17,17 +17,17 @@ const formatSeedForDisplay = (seed: number): string => {
 const parseSeedInput = (input: string): number => {
   // Handle empty input or "aleatorio"
   if (!input || input.trim() === '' || input.toLowerCase() === 'aleatorio') {
-    return 0;
+    return generateFalSeed(); // Generate new seed immediately instead of using 0
   }
 
   const cleanInput = input.replace(/[^0-9]/g, '');
-  if (!cleanInput) return 0;
+  if (!cleanInput) return generateFalSeed(); // Generate new seed if no valid numbers
   
   // Convert to number
   const num = Number(cleanInput);
   
-  // If number is 0, return 0 (random)
-  if (num === 0) return 0;
+  // If number is 0, generate a new seed
+  if (num === 0) return generateFalSeed();
   
   // Handle numbers with more than 7 digits
   if (cleanInput.length > 7) {
@@ -41,27 +41,33 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [inputValue, setInputValue] = useState(formatSeedForDisplay(value));
 
-  const handleSeedChange = (input: string) => {
-    setInputValue(input);
-    const parsedValue = parseSeedInput(input);
-    onChange(parsedValue);
-  };
-
+  // Generate a new random seed when requested or needed
   const handleRandomSeed = () => {
     const newSeed = generateFalSeed();
     setInputValue(String(newSeed));
     onChange(newSeed);
   };
 
+  // For clear button and "aleatorio" option, generate a new seed
   const handleClearSeed = () => {
+    const newSeed = generateFalSeed();
     setInputValue('aleatorio');
-    onChange(0);
+    onChange(newSeed);
+  };
+
+  const handleSeedChange = (input: string) => {
+    setInputValue(input);
+    const parsedValue = parseSeedInput(input);
+    onChange(parsedValue);
   };
 
   // Update input value when prop changes (e.g., on initial load)
-  if (formatSeedForDisplay(value) !== inputValue) {
-    setInputValue(formatSeedForDisplay(value));
-  }
+  useEffect(() => {
+    const displayValue = value === 0 ? 'aleatorio' : String(value);
+    if (displayValue !== inputValue) {
+      setInputValue(displayValue);
+    }
+  }, [value]);
 
   return (
     <div className="space-y-2">
@@ -90,7 +96,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             className="text-sm" 
             style={{ color: themeParams.hint_color }}
           >
-            Mismo seed + prompt = misma imagen. Usa 0 o "aleatorio" para seed aleatorio.
+            Mismo seed + prompt = misma imagen. Usa "aleatorio" para seed aleatorio.
           </p>
         )}
       </div>

--- a/src/components/generate/ImageParameters/SeedInput.tsx
+++ b/src/components/generate/ImageParameters/SeedInput.tsx
@@ -10,48 +10,58 @@ interface SeedInputProps {
 }
 
 const formatSeedForDisplay = (seed: number): string => {
+  if (seed === 0) return 'aleatorio';
   return String(seed);
 };
 
 const parseSeedInput = (input: string): number => {
-  if (!input || input.trim() === '') return 0;
+  // Handle empty input or "aleatorio"
+  if (!input || input.trim() === '' || input.toLowerCase() === 'aleatorio') {
+    return 0;
+  }
+
   const cleanInput = input.replace(/[^0-9]/g, '');
   if (!cleanInput) return 0;
   
-  // Convert to 7-digit number
-  if (cleanInput.length < 7) {
-    // If less than 7 digits, pad with leading digits starting with 1
-    return Number('1' + cleanInput.padStart(6, '0'));
-  }
+  // Convert to number
+  const num = Number(cleanInput);
   
+  // If number is 0, return 0 (random)
+  if (num === 0) return 0;
+  
+  // Handle numbers with more than 7 digits
   if (cleanInput.length > 7) {
-    // If more than 7 digits, take first 7
     return Number(cleanInput.slice(0, 7));
   }
   
-  // Exactly 7 digits
-  const num = Number(cleanInput);
-  if (num < 1000000) {
-    // Ensure it starts with 1 if somehow less than 1000000
-    return 1000000 + (num % 1000000);
-  }
   return num;
 };
 
 export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
   const [showHelp, setShowHelp] = useState(false);
+  const [inputValue, setInputValue] = useState(formatSeedForDisplay(value));
 
   const handleSeedChange = (input: string) => {
-    onChange(parseSeedInput(input));
+    setInputValue(input);
+    const parsedValue = parseSeedInput(input);
+    onChange(parsedValue);
   };
 
   const handleRandomSeed = () => {
-    onChange(generateFalSeed());
+    const newSeed = generateFalSeed();
+    setInputValue(String(newSeed));
+    onChange(newSeed);
   };
 
   const handleClearSeed = () => {
-    onChange(0);  // Just clear to 0
+    setInputValue('aleatorio');
+    onChange(0);
   };
+
+  // Update input value when prop changes (e.g., on initial load)
+  if (formatSeedForDisplay(value) !== inputValue) {
+    setInputValue(formatSeedForDisplay(value));
+  }
 
   return (
     <div className="space-y-2">
@@ -80,19 +90,16 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             className="text-sm" 
             style={{ color: themeParams.hint_color }}
           >
-            Mismo seed + prompt = misma imagen. Usa 0 para seed aleatorio.
+            Mismo seed + prompt = misma imagen. Usa 0 o "aleatorio" para seed aleatorio.
           </p>
         )}
       </div>
       <div className="flex gap-2">
         <input
           type="text"
-          inputMode="numeric"
-          pattern="[0-9]*"
-          value={formatSeedForDisplay(value)}
+          value={inputValue}
           onChange={(e) => handleSeedChange(e.target.value)}
-          placeholder="0 para aleatorio"
-          maxLength={7}
+          placeholder="aleatorio"
           className="w-full px-3 py-1.5 rounded-md border text-sm transition-colors focus:outline-none focus:ring-1 focus:ring-offset-1"
           style={{
             backgroundColor: themeParams.secondary_bg_color,
@@ -107,7 +114,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             backgroundColor: themeParams.button_color,
             color: themeParams.button_text_color
           }}
-          title="Limpiar seed (usar 0 para aleatorio)"
+          title="Usar seed aleatorio"
         >
           <X className="h-4 w-4" />
         </button>

--- a/src/components/generate/ImageParameters/SeedInput.tsx
+++ b/src/components/generate/ImageParameters/SeedInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { RotateCcw, X, Info } from 'lucide-react';
 import type { TelegramThemeParams } from '@/types/telegram';
+import { generateFalSeed } from '@/utils/seed';
 
 interface SeedInputProps {
   value: number;
@@ -40,28 +41,36 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [inputValue, setInputValue] = useState(formatSeedForDisplay(value));
 
-  // For random seed requests
+  // Generate a specific random seed and display it
   const handleRandomSeed = () => {
-    setInputValue('aleatorio');
-    onChange(0);
+    console.log('Generating new random seed...'); // Debug log
+    const newSeed = generateFalSeed();
+    console.log('Generated new seed:', newSeed); // Debug log
+    setInputValue(String(newSeed));
+    onChange(newSeed);
   };
 
-  // For clear button and "aleatorio" option
+  // Set to "aleatorio" (0) for random seed
   const handleClearSeed = () => {
+    console.log('Setting seed to random (0)'); // Debug log
     setInputValue('aleatorio');
     onChange(0);
   };
 
   const handleSeedChange = (input: string) => {
+    console.log('Seed input changed to:', input); // Debug log
     setInputValue(input);
     const parsedValue = parseSeedInput(input);
+    console.log('Parsed seed value:', parsedValue); // Debug log
     onChange(parsedValue);
   };
 
   // Update input value when prop changes (e.g., on initial load)
   useEffect(() => {
+    console.log('Seed value prop changed to:', value); // Debug log
     const displayValue = formatSeedForDisplay(value);
     if (displayValue !== inputValue) {
+      console.log('Updating input display to:', displayValue); // Debug log
       setInputValue(displayValue);
     }
   }, [value]);
@@ -93,7 +102,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             className="text-sm" 
             style={{ color: themeParams.hint_color }}
           >
-            Mismo seed + prompt = misma imagen. Usa "aleatorio" o 0 para seed aleatorio.
+            Mismo seed + prompt = misma imagen. "Aleatorio" = nuevo seed aleatorio cada vez.
           </p>
         )}
       </div>
@@ -117,7 +126,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             backgroundColor: themeParams.button_color,
             color: themeParams.button_text_color
           }}
-          title="Usar seed aleatorio"
+          title="Usar seed aleatorio cada vez"
         >
           <X className="h-4 w-4" />
         </button>
@@ -128,7 +137,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             backgroundColor: themeParams.button_color,
             color: themeParams.button_text_color
           }}
-          title="Generar seed aleatorio"
+          title="Generar un seed aleatorio específico"
         >
           <RotateCcw className="h-4 w-4" />
         </button>

--- a/src/components/generate/ImageParameters/SeedInput.tsx
+++ b/src/components/generate/ImageParameters/SeedInput.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { RotateCcw, X, Info } from 'lucide-react';
 import type { TelegramThemeParams } from '@/types/telegram';
-import { generateFalSeed } from '@/utils/seed';
 
 interface SeedInputProps {
   value: number;
@@ -17,17 +16,17 @@ const formatSeedForDisplay = (seed: number): string => {
 const parseSeedInput = (input: string): number => {
   // Handle empty input or "aleatorio"
   if (!input || input.trim() === '' || input.toLowerCase() === 'aleatorio') {
-    return generateFalSeed(); // Generate new seed immediately instead of using 0
+    return 0; // Use 0 for random
   }
 
   const cleanInput = input.replace(/[^0-9]/g, '');
-  if (!cleanInput) return generateFalSeed(); // Generate new seed if no valid numbers
+  if (!cleanInput) return 0; // Use 0 for random if no valid numbers
   
   // Convert to number
   const num = Number(cleanInput);
   
-  // If number is 0, generate a new seed
-  if (num === 0) return generateFalSeed();
+  // If number is 0, use it (for random)
+  if (num === 0) return 0;
   
   // Handle numbers with more than 7 digits
   if (cleanInput.length > 7) {
@@ -41,18 +40,16 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [inputValue, setInputValue] = useState(formatSeedForDisplay(value));
 
-  // Generate a new random seed when requested or needed
+  // For random seed requests
   const handleRandomSeed = () => {
-    const newSeed = generateFalSeed();
-    setInputValue(String(newSeed));
-    onChange(newSeed);
+    setInputValue('aleatorio');
+    onChange(0);
   };
 
-  // For clear button and "aleatorio" option, generate a new seed
+  // For clear button and "aleatorio" option
   const handleClearSeed = () => {
-    const newSeed = generateFalSeed();
     setInputValue('aleatorio');
-    onChange(newSeed);
+    onChange(0);
   };
 
   const handleSeedChange = (input: string) => {
@@ -63,7 +60,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
 
   // Update input value when prop changes (e.g., on initial load)
   useEffect(() => {
-    const displayValue = value === 0 ? 'aleatorio' : String(value);
+    const displayValue = formatSeedForDisplay(value);
     if (displayValue !== inputValue) {
       setInputValue(displayValue);
     }
@@ -96,7 +93,7 @@ export function SeedInput({ value, onChange, themeParams }: SeedInputProps) {
             className="text-sm" 
             style={{ color: themeParams.hint_color }}
           >
-            Mismo seed + prompt = misma imagen. Usa "aleatorio" para seed aleatorio.
+            Mismo seed + prompt = misma imagen. Usa "aleatorio" o 0 para seed aleatorio.
           </p>
         )}
       </div>


### PR DESCRIPTION
This PR improves the seed input component by:

- Fixing the issue where deleting all input defaults to 1000000 instead of 0/random
- Making the 0/random seed setting persist when reopening the app
- Adding proper display of "aleatorio" for 0/random seed values
- Improving input handling to accept both "aleatorio" text and 0 as valid inputs for random seed
- Updating help text and tooltips to be more clear about random seed options

Test cases:
1. Delete all input -> should show "aleatorio" and set seed to 0
2. Type "aleatorio" -> should be accepted and set seed to 0
3. Type "0" -> should be interpreted as random seed
4. Close and reopen app with random seed -> should persist and show "aleatorio"
5. Enter valid seed number -> should persist when reopening